### PR TITLE
Fix bus emission to send keyword arguments

### DIFF
--- a/logic/state/app_state.py
+++ b/logic/state/app_state.py
@@ -2,8 +2,19 @@ from .models import AppStateModel, TrackState, ClipSlotState
 from ..bus import bus
 
 class AppState:
-    def __init__(self): self.m = AppStateModel()
-    def _emit(self, key, **data): bus.emit(f"state:{key}", data)
+    def __init__(self):
+        self.m = AppStateModel()
+
+    def _emit(self, key, **data):
+        """Proxy event emission through the global bus.
+
+        The previous implementation forwarded the ``data`` dictionary as a single
+        positional argument which meant subscribers received a dict instead of
+        the expected keyword arguments.  This made handlers such as
+        ``on_volume(track, value)`` fail with ``TypeError``.  Expanding ``data``
+        fixes the issue so callbacks receive named arguments.
+        """
+        bus.emit(f"state:{key}", **data)
 
     def init_project(self, tracks=8, scenes=8):
         self.m.scenes_count = scenes

--- a/tests/test_app_state_bus.py
+++ b/tests/test_app_state_bus.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+from kivy.clock import Clock
+
+# Ensure project root is on the import path for test execution
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from logic.state.app_state import AppState
+from logic.bus import bus
+
+
+def test_set_track_volume_emits_named_arguments():
+    """AppState should emit track and value as keyword arguments."""
+    received = []
+
+    def handler(track, value):
+        received.append((track, value))
+
+    bus._subs.clear()
+    bus.on("state:track_volume", handler)
+
+    state = AppState()
+    state.init_project(tracks=1, scenes=1)
+    state.set_track_volume(0, 0.5)
+
+    # Process scheduled bus event
+    Clock.tick()
+
+    assert received == [(0, 0.5)]


### PR DESCRIPTION
## Summary
- fix `AppState._emit` to expand keyword data
- add regression test for track volume event emission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8b2dbb48833282e54bc6b47a36db